### PR TITLE
Remove --red-to-ops, --ops-to-red, and --pth arguments

### DIFF
--- a/src/args.py
+++ b/src/args.py
@@ -17,9 +17,6 @@ def get_args():
 
     support = parser.add_argument_group(title="support")
     directories = parser.add_argument_group(title="directories")
-    modes = parser.add_argument_group(title="modes").add_mutually_exclusive_group(
-        required=True
-    )
     extras = parser.add_argument_group(title="extras")
 
     support.add_argument(
@@ -45,22 +42,6 @@ def get_args():
         help="folder where cross-seedable .torrent files will be saved",
     )
 
-    modes.add_argument(
-        "--ops-to-red",
-        action="store_true",
-        help="consider torrents with the OPS source flag",
-    )
-    modes.add_argument(
-        "--red-to-ops",
-        action="store_true",
-        help="consider torrents with the RED source flag",
-    )
-
-    extras.add_argument(
-        "--pth",
-        action="store_true",
-        help="calculate infohashes with the PTH source flag too",
-    )
     extras.add_argument(
         "--download",
         action="store_true",

--- a/src/main.py
+++ b/src/main.py
@@ -8,6 +8,8 @@ from filesystem import create_folder, get_files, get_filename
 from parser import get_torrent_data, get_new_hash, get_source, save_torrent_data
 from progress import Progress
 
+ops_sources = (b"OPS", b"APL")
+red_sources = (b"RED", b"PTH")
 
 def main():
     create_folder(args.folder_out)
@@ -27,14 +29,12 @@ def main():
 
         print(f"{i}/{p.total}) {filename}")
 
-        if source == b"OPS" and args.ops_to_red:
+        if source in ops_sources:
             api = red
-            new_sources = [b"RED"]
-            if args.pth:
-                new_sources.append(b"PTH")
-        elif source in (b"PTH", b"RED") and args.red_to_ops:
-            new_sources = [b"OPS"]
+            new_sources = red_sources
+        elif source in red_sources:
             api = ops
+            new_sources = ops_sources
         else:
             p.skipped.print(f"Skipped: source is {source.decode('utf-8')}.")
             continue
@@ -77,12 +77,7 @@ def main():
                     )
                 break  # Skip the PTH check if found on RED
             elif torrent_details["error"] in known_errors:
-                if not args.pth:
-                    p.not_found.print(
-                        f"Not found with source {new_source}.",
-                        add=False
-                    )
-                elif args.pth and i == 1:
+                if i == 1:
                     p.not_found.print(
                         f"Not found with sources "
                         f"{', '.join(x.decode('utf-8') for x in new_sources)}.",

--- a/src/main.py
+++ b/src/main.py
@@ -49,7 +49,7 @@ def main():
 
             p.skipped.print(f"Skipped: source is {print_source}.")
             continue
-
+        
         for i, new_source in enumerate(new_sources, 0):
             hash_ = get_new_hash(torrent_data, new_source)
             torrent_details = api.find_torrent(hash_)
@@ -57,6 +57,7 @@ def main():
             new_source = new_source.decode("utf-8")
             known_errors = ("bad hash parameter", "bad parameters")
 
+            torrent_successful = False
             if status == "success":
                 torrent_filepath = get_torrent_filepath(
                     torrent_details, api.sitename, args.folder_out
@@ -86,6 +87,7 @@ def main():
                         f"Found with source {new_source}, "
                         f"but the .torrent already exists."
                     )
+                torrent_successful = True
                 break  # Skip the other source hash checks if successful
             elif torrent_details["error"] in known_errors:
                 if i == 1:
@@ -94,12 +96,14 @@ def main():
                         f"{', '.join(x.decode('utf-8') for x in new_sources)}.",
                         add=False,
                     )
-                p.not_found.increment()
             else:
                 p.error.print(
                     f"Unexpected error while using source {new_source}"
                     f"{Fore.LIGHTBLACK_EX}:\n{str(torrent_details)}"
                 )
+
+        if not torrent_successful:
+            p.not_found.increment()
 
     print(p.report())
 

--- a/src/main.py
+++ b/src/main.py
@@ -9,8 +9,8 @@ from parser import get_torrent_data, get_new_hash, get_source, save_torrent_data
 from progress import Progress
 from urllib.parse import urlparse
 
-ops_sources = (b"OPS", b"APL")
-red_sources = (b"RED", b"PTH")
+ops_sources = (b"OPS", b"APL", b"")
+red_sources = (b"RED", b"PTH", b"")
 
 ops_announce = "home.opsfet.ch"
 red_announce = "flacsfor.me"
@@ -93,7 +93,7 @@ def main():
                 if i == 1:
                     p.not_found.print(
                         f"Not found with sources "
-                        f"{', '.join(x.decode('utf-8') for x in new_sources)}.",
+                        f"{', '.join(x.decode('utf-8') or 'empty' for x in new_sources)}.",
                         add=False,
                     )
             else:

--- a/src/main.py
+++ b/src/main.py
@@ -29,11 +29,16 @@ def main():
         except AssertionError:
             p.error.print("Decoding error.")
             continue
-        source = get_source(torrent_data)
 
         print(f"{i}/{p.total}) {filename}")
 
-        announce_url = urlparse(torrent_data[b'announce'])
+        try:
+            announce_data = torrent_data[b'announce']
+        except:
+            p.error.print("No announce URL found.")
+            continue
+
+        announce_url = urlparse(announce_data)
         announce_loc = announce_url.netloc.decode('utf-8')
         if announce_loc == ops_announce:
             api = red
@@ -43,10 +48,11 @@ def main():
             new_sources = ops_sources
         else:
             try:
-                print_source = source.decode('utf-8')
+                print_source = get_source(torrent_data).decode('utf-8')
             except:
                 print_source = "empty"
 
+            # TODO: make this message clearer
             p.skipped.print(f"Skipped: source is {print_source}.")
             continue
         

--- a/src/main.py
+++ b/src/main.py
@@ -54,7 +54,12 @@ def main():
             hash_ = get_new_hash(torrent_data, new_source)
             torrent_details = api.find_torrent(hash_)
             status = torrent_details["status"]
-            new_source = new_source.decode("utf-8")
+
+            try:
+                new_source = new_source.decode("utf-8")
+            except:
+                new_source = "empty"
+
             known_errors = ("bad hash parameter", "bad parameters")
 
             torrent_successful = False

--- a/src/main.py
+++ b/src/main.py
@@ -32,24 +32,35 @@ def main():
             p.error.print("Decoding error.")
             continue
 
-        try:
-            announce_data = torrent_data[b'announce']
-        except:
-            p.error.print("No announce URL found.")
-            continue
-
-        announce_url = urlparse(announce_data)
-        announce_loc = announce_url.netloc.decode('utf-8')
-
-        if announce_loc == ops_announce:
-            api = red
-            new_sources = red_sources
-        elif announce_loc == red_announce:
-            api = ops
-            new_sources = ops_sources
+        source = get_source(torrent_data)
+        if source is None:
+            try:
+                announce_data = torrent_data[b'announce']
+                announce_url = urlparse(announce_data)
+                announce_loc = announce_url.netloc.decode('utf-8')
+            except:
+                p.error.print("No source flag or valid announce url found.")
+                continue
+            
+            if announce_loc == ops_announce:
+                api = red
+                new_sources = red_sources
+            elif announce_loc == red_announce:
+                api = ops
+                new_sources = ops_sources
+            else:
+                p.skipped.print(f"Skipped: Torrent announces to {announce_loc} and source flag is absent.")
+                continue
         else:
-            p.skipped.print(f"Skipped: Torrent announces to {announce_loc}")
-            continue
+            if source in ops_sources:
+                api = red
+                new_sources = red_sources
+            elif source in red_sources:
+                api = ops
+                new_sources = ops_sources
+            else:
+                p.skipped.print(f"Skipped: Source flag is {source.decode('utf8')}.")
+                continue
         
         for i, new_source in enumerate(new_sources, 0):
             hash_ = get_new_hash(torrent_data, new_source)

--- a/src/main.py
+++ b/src/main.py
@@ -24,13 +24,13 @@ def main():
 
     for i, torrent_path in enumerate(local_torrents, 1):
         filename = get_filename(torrent_path)
+        print(f"{i}/{p.total}) {filename}")
+
         try:
             torrent_data = get_torrent_data(torrent_path)
         except AssertionError:
             p.error.print("Decoding error.")
             continue
-
-        print(f"{i}/{p.total}) {filename}")
 
         try:
             announce_data = torrent_data[b'announce']
@@ -40,6 +40,7 @@ def main():
 
         announce_url = urlparse(announce_data)
         announce_loc = announce_url.netloc.decode('utf-8')
+
         if announce_loc == ops_announce:
             api = red
             new_sources = red_sources
@@ -47,13 +48,7 @@ def main():
             api = ops
             new_sources = ops_sources
         else:
-            try:
-                print_source = get_source(torrent_data).decode('utf-8')
-            except:
-                print_source = "empty"
-
-            # TODO: make this message clearer
-            p.skipped.print(f"Skipped: source is {print_source}.")
+            p.skipped.print(f"Skipped: Torrent announces to {announce_loc}")
             continue
         
         for i, new_source in enumerate(new_sources, 0):

--- a/src/parser.py
+++ b/src/parser.py
@@ -7,7 +7,7 @@ def get_source(torrent_data):
     try:
         return torrent_data[b"info"][b"source"]
     except KeyError:
-        return b"empty"
+        return None
 
 
 def get_new_hash(torrent_data, new_source):


### PR DESCRIPTION
This matches the default behavior of pollenizer. Instead of having to run crops twice to go from OPS to RED and vice versa, it will use the source flag to do it automatically. 

From what I've seen from people on the forum, there are torrents on both sites which have an empty source flag. Should crops check the announce url in that case?