### PR TITLE
Screen input directory for new infohash matches.

### DIFF
--- a/src/downloader.py
+++ b/src/downloader.py
@@ -16,8 +16,6 @@ def get_torrent_filepath(torrent_details, source, folder_out):
         f'[{source}].torrent'
     )
     torrent_filepath = os.path.join(folder_out, filename)
-    if os.path.isfile(torrent_filepath):
-        return None
     return torrent_filepath
 
 

--- a/src/main.py
+++ b/src/main.py
@@ -5,8 +5,19 @@ from args import get_args
 from config import Config
 from downloader import get_torrent_id, get_torrent_url, get_torrent_filepath, download_torrent
 from filesystem import create_folder, get_files, get_filename
-from parser import get_torrent_data, get_new_hash, get_source, save_torrent_data
+from parser import get_torrent_data, get_infohash, get_new_hash, get_source, save_torrent_data
 from progress import Progress
+import json
+
+def gen_infohash_dict(local_torrents):
+    infohash_dict = {}
+    for file in local_torrents:
+        with open(file, mode="rb") as f:
+            torrent_data = get_torrent_data(file)
+            infohash = get_infohash(torrent_data)
+            infohash_dict[infohash] = torrent_data[b'info'][b'name'].decode('utf-8')
+
+    return infohash_dict
 
 
 def main():

--- a/src/main.py
+++ b/src/main.py
@@ -7,7 +7,6 @@ from downloader import get_torrent_id, get_torrent_url, get_torrent_filepath, do
 from filesystem import create_folder, get_files, get_filename
 from parser import get_torrent_data, get_infohash, get_new_hash, get_source, save_torrent_data
 from progress import Progress
-import json
 
 def gen_infohash_dict(local_torrents):
     infohash_dict = {}

--- a/src/main.py
+++ b/src/main.py
@@ -53,20 +53,20 @@ def main():
             continue
 
         # TODO: make it so you don't calc hashes twice or find a better flow control for this.
-        found_crossseed = False
+        found_infohash_match = False
         for new_source in new_sources:
             hash_ = get_new_hash(torrent_data, new_source)
             try:
                 dest_hash_file = infohash_dict[hash_]
                 p.already_exists.print(
-                    f"Already cross-seeding {dest_hash_file} with source {new_source.decode('utf-8')}."
+                    f"An infohash match was found in the output directory with source {new_source.decode('utf-8')}."
                 )
-                found_crossseed = True
+                found_infohash_match = True
                 break
             except KeyError:
                 continue
 
-        if found_crossseed:
+        if found_infohash_match:
             continue
 
         for i, new_source in enumerate(new_sources, 0):

--- a/src/main.py
+++ b/src/main.py
@@ -8,14 +8,12 @@ from filesystem import create_folder, get_files, get_filename
 from parser import get_torrent_data, get_infohash, get_new_hash, get_source, save_torrent_data
 from progress import Progress
 
-def gen_infohash_dict(local_torrents):
+def gen_infohash_dict(files):
     infohash_dict = {}
-    for file in local_torrents:
-        with open(file, mode="rb") as f:
-            torrent_data = get_torrent_data(file)
-            infohash = get_infohash(torrent_data)
-            infohash_dict[infohash] = get_filename(file)
-
+    for file in files:
+        torrent_data = get_torrent_data(file)
+        infohash = get_infohash(torrent_data)
+        infohash_dict[infohash] = torrent_data[b"info"][b"name"].decode("utf8")
     return infohash_dict
 
 

--- a/src/main.py
+++ b/src/main.py
@@ -81,17 +81,16 @@ def main():
                 torrent_filepath = get_torrent_filepath(
                     torrent_details, api.sitename, args.folder_out
                 )
+                torrent_id = get_torrent_id(torrent_details)
 
-                if torrent_filepath and args.download:
-                    torrent_id = get_torrent_id(torrent_details)
+                if args.download:
                     download_torrent(api, torrent_filepath, torrent_id)
 
                     p.generated.print(
                         f"Found with source {new_source} "
                         f"and downloaded as '{get_filename(torrent_filepath)}'."
                     )
-                elif torrent_filepath:
-                    torrent_id = get_torrent_id(torrent_details)
+                else:
                     torrent_data[b"announce"] = api.announce_url
                     torrent_data[b"comment"] = get_torrent_url(api.site_url, torrent_id)
 

--- a/src/main.py
+++ b/src/main.py
@@ -54,12 +54,12 @@ def main():
 
         # TODO: make it so you don't calc hashes twice or find a better flow control for this.
         found_crossseed = False
-        for src in new_sources:
-            hash_ = get_new_hash(torrent_data, src)
+        for new_source in new_sources:
+            hash_ = get_new_hash(torrent_data, new_source)
             try:
                 dest_hash_file = infohash_dict[hash_]
                 p.already_exists.print(
-                    f"Already cross-seeding {dest_hash_file} with source {new_source}."
+                    f"Already cross-seeding {dest_hash_file} with source {new_source.decode('utf-8')}."
                 )
                 found_crossseed = True
                 break

--- a/src/main.py
+++ b/src/main.py
@@ -59,7 +59,7 @@ def main():
             try:
                 dest_hash_file = infohash_dict[hash_]
                 p.already_exists.print(
-                    f"An infohash match was found in the output directory with source {new_source.decode('utf-8')}."
+                    f"An infohash match was found in the input directory with source {new_source.decode('utf-8')}."
                 )
                 found_infohash_match = True
                 break

--- a/src/parser.py
+++ b/src/parser.py
@@ -9,12 +9,16 @@ def get_source(torrent_data):
     except KeyError:
         return b"empty"
 
+def get_infohash(torrent_data):
+    encoded_info = bencoder.encode(torrent_data[b"info"])
+    hash = sha1(encoded_info).hexdigest().upper()
+
+    return hash
 
 def get_new_hash(torrent_data, new_source):
     torrent_data[b"info"][b"source"] = new_source
-    hash = sha1(bencoder.encode(torrent_data[b"info"])).hexdigest().upper()
 
-    return hash
+    return get_infohash(torrent_data)
 
 
 def get_torrent_data(filename):


### PR DESCRIPTION
When trying to find torrents, crops can now tell whether a torrent with an infohash corresponding to a different destination is present in the source directory. This means that there's a lot of savings in API requests after the first time running the program. 

After both of the pull requests that I've made get merged I will clean up the flow control, etc.